### PR TITLE
Adds camelized_attributes method

### DIFF
--- a/lib/jserializer/serializer.rb
+++ b/lib/jserializer/serializer.rb
@@ -8,6 +8,11 @@ class JSerializer::Serializer < JSerializer::Base
     @json.merge!(attrs)
   end
 
+  def camelized_attributes(*names, **attrs)
+    names.each { |name| @json[name.to_s.camelize(:lower)] = @object.send(name) }
+    @json.merge!(attrs)
+  end
+
   def embeds_many(*args)
     assign_association(*args) do |associated|
       JSerializer::CollectionSerializer.new(associated, **@options).as_json

--- a/lib/jserializer/version.rb
+++ b/lib/jserializer/version.rb
@@ -1,3 +1,3 @@
 module JSerializer
-  VERSION = "0.0.1"
+  VERSION = "0.0.2"
 end

--- a/spec/blueprints.rb
+++ b/spec/blueprints.rb
@@ -1,5 +1,5 @@
 factory(Employee) do
-  blueprint :leader, name: 'Leader'
+  blueprint :leader, name: 'Leader', last_name: 'Snow'
   blueprint :employee, name: 'Employee', leader: leader
   blueprint :employee2, name: 'Employee 2', leader: leader
 end

--- a/spec/migrations/3_add_last_name_to_employees.rb
+++ b/spec/migrations/3_add_last_name_to_employees.rb
@@ -1,0 +1,5 @@
+class AddLastNameToEmployees < ActiveRecord::Migration
+  def change
+    add_column :employees, :last_name, :string
+  end
+end

--- a/spec/serializer_spec.rb
+++ b/spec/serializer_spec.rb
@@ -117,4 +117,25 @@ describe JSerializer::Serializer do
       expect(json_of(leader_serializer)).to eq(name: 'Mr. Leader', employees: [{name: 'Mr. Employee', employees: []}])
     end
   end
+
+  describe ".camelized_attributes" do
+    it "converts object's attributes to camel case" do
+      EmployeeSerializer.class_eval do
+        def serialize
+          camelized_attributes :last_name
+        end
+      end
+      expect(json_of(leader_serializer)).to eq(lastName: 'Snow')
+    end
+
+    it "won't convert custom attributes" do
+      EmployeeSerializer.class_eval do
+        def serialize(**_)
+          camelized_attributes last_name: "Mr. Snow"
+        end
+      end
+
+      expect(json_of(leader_serializer)).to eq(last_name: 'Mr. Snow')
+    end
+  end
 end


### PR DESCRIPTION
It will convert object's property names into camelCase when serializing. Useful beacause on JS side we use camel case and a serializer stands at the intersection between Ruby and JS. This will prevent cases where we have:

``` ruby
attributes showQuickTour: model.show_quick_tour,
           showPublishQuickTour: model.show_publish_quick_tour,
           videoWalkthroughHidden: model.video_walkthrough_hidden,
           essentialTipsHidden: model.essential_tips_hidden,
           greatWrapsHidden: model.great_wraps_hidden
```

Instead we can write:

``` ruby
camelized_attributes :show_quick_tour, :show_publish_quick_tour, :video_walkthrough_hidden, :essential_tips_hidden, :great_wraps_hidden
```

Hm... maybe we should consider making this default behaviour of `attributes`?

@francisli @dana11235 
